### PR TITLE
Correção na chamada do Quick sort

### DIFF
--- a/src/sorting/QuickSort.js
+++ b/src/sorting/QuickSort.js
@@ -18,7 +18,7 @@ function quicksort(vetor, inferior, superior) {
 
 		pivo_pos = i + 1;
 		quicksort(vetor, inferior, pivo_pos - 1);
-		quicksort(vetor, pivo_pos + 1, superior - 1);
+		quicksort(vetor, pivo_pos + 1, superior);
 		return vetor;
 	}
 }


### PR DESCRIPTION
Quando a ordenação e feita para o lado direito e enviado o superior com o desconto de menos 1, porém quando atribuímos o pivô daquele sub vetor também tem o desconto de menos 1, ou seja, o ultimo elemento nunca é ordenado.